### PR TITLE
4 test fixtures tests are not logged

### DIFF
--- a/src/JUnit.Xml.TestLogger/JUnitXmlTestLogger.cs
+++ b/src/JUnit.Xml.TestLogger/JUnitXmlTestLogger.cs
@@ -37,6 +37,9 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.JUnit.Xml.TestLogger
         public const string MethodFormatKey = "MethodFormat";
         public const string FailureBodyFormatKey = "FailureBodyFormat";
 
+        public const string TestCaseParserUnknownType = "UnknownType";
+        public const string TestCaseParserErrorTemplate = "JUnitXML Logger: Unable to parse the test name '{0}' into a type and method. Using Type='" + TestCaseParserUnknownType + "' and Method='{0}'";
+
         private const string ResultStatusPassed = "Passed";
         private const string ResultStatusFailed = "Failed";
 
@@ -83,6 +86,20 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.JUnit.Xml.TestLogger
             Verbose
         }
 
+        private enum NameParseStep
+        {
+            FindMethod,
+            FindType,
+            Done
+        }
+
+        private enum NameParseState
+        {
+            Default,
+            Parenthesis,
+            String
+        }
+
         public MethodFormat MethodFormatOption { get; private set; } = MethodFormat.Default;
 
         public FailureBodyFormat FailureBodyFormatOption { get; private set; } = FailureBodyFormat.Default;
@@ -110,6 +127,173 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.JUnit.Xml.TestLogger
             }
 
             return roots;
+        }
+
+        /// <summary>
+        /// This method attempts to parse out a Type and Method name from a given string. When a clearly
+        /// invalid output is encountered, a message is written to the console.
+        /// </summary>
+        /// <remarks>
+        /// This is fragile, because the fully qualified name is constructed by a test adapter and there is
+        /// no enforcement that the FQN starts with metadata type name, or is of the expected format.
+        /// </remarks>
+        /// <example>
+        /// Some invalid strings, such as "#.#" will 'successfully' parse, because the possible input space
+        /// is very large and this parser is relativly simple.
+        /// </example>
+        /// <param name="fullyQualifedName">
+        /// String like 'type.method', where type and or method may be followed by parenthesis containing
+        /// parameter values. The string may be prefixed with namespaces.
+        /// </param>
+        /// <returns>
+        /// A Tuple of strings: typeName, methodName. Output will always be provided. In the case that
+        /// input was obviously invalid, then a string indicating the error will be the first value
+        /// and the input string will be the second.
+        /// </returns>
+        public static Tuple<string, string> ParseTestCaseName(string fullyQualifedName)
+        {
+            var metadataTypeName = string.Empty;
+            var metadataMethodName = string.Empty;
+
+            var step = NameParseStep.FindMethod;
+            var state = NameParseState.Default;
+
+            var tuptuo = new List<char>();
+
+            try
+            {
+                var eman = fullyQualifedName.ToCharArray().Reverse().ToArray();
+
+                for (int i = 0; i < eman.Count(); i++)
+                {
+                    var thisChar = eman[i];
+                    if (state == NameParseState.Default)
+                    {
+                        if (thisChar == '(' || thisChar == '"' || thisChar == '\\')
+                        {
+                            throw new Exception("Found invalid characters");
+                        }
+                        else if (thisChar == ')')
+                        {
+                            if (tuptuo.Count > 0)
+                            {
+                                throw new Exception("The closing parenthesis we detected wouldn't be the last character in the output string. This isn't acceptable because we aren't in a string");
+                            }
+
+                            state = NameParseState.Parenthesis;
+                            tuptuo.Add(thisChar);
+                        }
+                        else if (thisChar == '.')
+                        {
+                            // Found the end of this element.
+                            if (step == NameParseStep.FindMethod)
+                            {
+                                if (tuptuo.Count == 0)
+                                {
+                                    throw new Exception("This shouldn't be an empty string");
+                                }
+
+                                tuptuo.Reverse();
+                                metadataMethodName = string.Join(string.Empty, tuptuo);
+
+                                // Prep the next step
+                                tuptuo = new List<char>();
+                                step = NameParseStep.FindType;
+                            }
+                            else if (step == NameParseStep.FindType)
+                            {
+                                if (tuptuo.Count == 0)
+                                {
+                                    throw new Exception("This shouldn't be an empty string");
+                                }
+
+                                tuptuo.Reverse();
+                                metadataTypeName = string.Join(string.Empty, tuptuo);
+
+                                // Done
+                                step = NameParseStep.Done;
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            // Part of the name to add
+                            tuptuo.Add(thisChar);
+                        }
+                    }
+                    else if (state == NameParseState.Parenthesis)
+                    {
+                        if (thisChar == ')' || thisChar == '\\' || thisChar == '.')
+                        {
+                            throw new Exception("Found invalid characters");
+                        }
+                        else if (thisChar == '(')
+                        {
+                            // If we found the beginning of the parenthesis block, we are back in default state
+                            state = NameParseState.Default;
+                            tuptuo.Add(thisChar);
+                        }
+                        else if (thisChar == '"')
+                        {
+                            // This must come at the end of a string, when escape characters aren't an issue, so we are
+                            // 'entering' string state, because of the reverse parsing.
+                            state = NameParseState.String;
+                            tuptuo.Add(thisChar);
+                        }
+                        else
+                        {
+                            tuptuo.Add(thisChar);
+                        }
+                    }
+                    else
+                    {
+                        // We are in String State.
+                        if (thisChar == '"')
+                        {
+                            if (eman.ElementAtOrDefault(i + 1) == '\\')
+                            {
+                                // The quote was escaped, so its atually a quote mark in a string
+                                tuptuo.Add(thisChar);
+                            }
+                            else
+                            {
+                                state = NameParseState.Parenthesis;
+                                tuptuo.Add(thisChar);
+                            }
+                        }
+                        else
+                        {
+                            tuptuo.Add(thisChar);
+                        }
+                    }
+                }
+
+                // We are done. If we are finding type, set that variable.
+                // Otherwise, ther was some issue, so leave the type blank.
+                if (step == NameParseStep.FindType)
+                {
+                    tuptuo.Reverse();
+                    metadataTypeName = string.Join(string.Empty, tuptuo);
+                }
+            }
+            catch (Exception)
+            {
+                // On exception, whipe out the type name
+                metadataTypeName = string.Empty;
+            }
+            finally
+            {
+                // If for any reason we don't have a Type Name
+                // we fall back on our safe option and notify the user
+                if (string.IsNullOrWhiteSpace(metadataTypeName))
+                {
+                    metadataTypeName = TestCaseParserUnknownType;
+                    metadataMethodName = fullyQualifedName;
+                    Console.WriteLine(string.Format(TestCaseParserErrorTemplate, fullyQualifedName));
+                }
+            }
+
+            return new Tuple<string, string>(metadataTypeName, metadataMethodName);
         }
 
         /// <summary>
@@ -247,15 +431,14 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.JUnit.Xml.TestLogger
         {
             TestResult result = e.Result;
 
-            if (TryParseName(result.TestCase.FullyQualifiedName, out var typeName, out var methodName, out _))
+            var parsedName = ParseTestCaseName(result.TestCase.FullyQualifiedName);
+
+            lock (this.resultsGuard)
             {
-                lock (this.resultsGuard)
-                {
-                    this.results.Add(new TestResultInfo(
-                        result,
-                        typeName,
-                        methodName));
-                }
+                this.results.Add(new TestResultInfo(
+                    result,
+                    parsedName.Item1,
+                    parsedName.Item2));
             }
         }
 
@@ -354,53 +537,6 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.JUnit.Xml.TestLogger
                 Error = error,
                 Time = time
             };
-        }
-
-        private static bool TryParseName(
-            string testCaseName,
-            out string metadataTypeName,
-            out string metadataMethodName,
-            out string metadataMethodArguments)
-        {
-            // This is fragile. The FQN is constructed by a test adapter.
-            // There is no enforcement that the FQN starts with metadata type name.
-            string typeAndMethodName;
-            var methodArgumentsStart = testCaseName.IndexOf('(');
-
-            if (methodArgumentsStart == -1)
-            {
-                typeAndMethodName = testCaseName.Trim();
-                metadataMethodArguments = string.Empty;
-            }
-            else
-            {
-                typeAndMethodName = testCaseName.Substring(0, methodArgumentsStart).Trim();
-                metadataMethodArguments = testCaseName.Substring(methodArgumentsStart).Trim();
-
-                if (metadataMethodArguments[metadataMethodArguments.Length - 1] != ')')
-                {
-                    metadataTypeName = null;
-                    metadataMethodName = null;
-                    metadataMethodArguments = null;
-                    return false;
-                }
-            }
-
-            var typeNameLength = typeAndMethodName.LastIndexOf('.');
-            var methodNameStart = typeNameLength + 1;
-
-            if (typeNameLength <= 0 || methodNameStart == typeAndMethodName.Length)
-            {
-                // No typeName is available
-                metadataTypeName = null;
-                metadataMethodName = null;
-                metadataMethodArguments = null;
-                return false;
-            }
-
-            metadataTypeName = typeAndMethodName.Substring(0, typeNameLength).Trim();
-            metadataMethodName = typeAndMethodName.Substring(methodNameStart).Trim();
-            return true;
         }
 
         private void InitializeImpl(TestLoggerEvents events, string outputPath)

--- a/src/JUnit.Xml.TestLogger/JUnitXmlTestLogger.cs
+++ b/src/JUnit.Xml.TestLogger/JUnitXmlTestLogger.cs
@@ -598,9 +598,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.JUnit.Xml.TestLogger
 
             var namespaceClass = result.TestCase
                 .FullyQualifiedName
-                .Substring(0, result.TestCase.FullyQualifiedName.IndexOf(result.TestCase.DisplayName) - 1);
-
-            var className = namespaceClass.Substring(namespaceClass.LastIndexOf('.') + 1);
+                .Substring(0, result.TestCase.FullyQualifiedName.IndexOf(result.Name) - 1);
 
             testcaseElement.SetAttributeValue("classname", namespaceClass);
 
@@ -610,7 +608,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.JUnit.Xml.TestLogger
             }
             else if (this.MethodFormatOption == MethodFormat.Class)
             {
-                testcaseElement.SetAttributeValue("name", className + "." + result.Name);
+                testcaseElement.SetAttributeValue("name", result.Type + "." + result.Name);
             }
             else
             {

--- a/test/JUnit.Xml.TestLogger.AcceptanceTests/JUnit.Xml.TestLogger.AcceptanceTests.csproj
+++ b/test/JUnit.Xml.TestLogger.AcceptanceTests/JUnit.Xml.TestLogger.AcceptanceTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <SourceRoot Condition="$(SourceRoot) == ''">..\..\</SourceRoot>
@@ -23,9 +23,12 @@
   <Target Name="TestTarget" AfterTargets="Build">
     <Message Importance="High" Text="... Building test assets" />
     <RemoveDir Directories="$(NuGetPackageRoot)/junitxml.testlogger" />
-    <Exec ContinueOnError="False" Command="dotnet build -c $(Configuration) -p:PackageVersion=$(PackageVersion) -p:RestoreConfigFile=$(TestRestoreConfig) -p:RestoreIgnoreFailedSources=true -p:RestoreNoCache=true $(TestCoreProject)"/>
-    <Exec ContinueOnError="False" Command="dotnet build -c $(Configuration) -p:PackageVersion=$(PackageVersion) -p:RestoreConfigFile=$(TestRestoreConfig) -p:RestoreIgnoreFailedSources=true -p:RestoreNoCache=true $(TestFullProject)"/>
-    <Exec ContinueOnError="False" Command="dotnet build -c $(Configuration) -p:PackageVersion=$(PackageVersion) -p:RestoreConfigFile=$(TestRestoreConfig) -p:RestoreIgnoreFailedSources=true -p:RestoreNoCache=true $(TestMultiProject)"/>
+    <Exec ContinueOnError="False" Command="dotnet build -c $(Configuration) -p:PackageVersion=$(PackageVersion) -p:RestoreConfigFile=$(TestRestoreConfig) -p:RestoreIgnoreFailedSources=true -p:RestoreNoCache=true $(TestCoreProject)" />
+    <Exec ContinueOnError="False" Command="dotnet build -c $(Configuration) -p:PackageVersion=$(PackageVersion) -p:RestoreConfigFile=$(TestRestoreConfig) -p:RestoreIgnoreFailedSources=true -p:RestoreNoCache=true $(TestFullProject)" />
+    <Exec ContinueOnError="False" Command="dotnet build -c $(Configuration) -p:PackageVersion=$(PackageVersion) -p:RestoreConfigFile=$(TestRestoreConfig) -p:RestoreIgnoreFailedSources=true -p:RestoreNoCache=true $(TestMultiProject)" />
     <Message Importance="High" Text="... Completed" />
   </Target>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\JUnit.Xml.TestLogger\JUnit.Xml.TestLogger.csproj" />
+  </ItemGroup>
 </Project>

--- a/test/JUnit.Xml.TestLogger.AcceptanceTests/JUnitTestLoggerAcceptanceTests.cs
+++ b/test/JUnit.Xml.TestLogger.AcceptanceTests/JUnitTestLoggerAcceptanceTests.cs
@@ -47,7 +47,7 @@ namespace JUnit.Xml.TestLogger.AcceptanceTests
 
             Assert.IsNotNull(node);
             Assert.AreEqual("JUnit.Xml.TestLogger.NetCore.Tests.dll", node.Attribute(XName.Get("name")).Value);
-            Assert.AreEqual("48", node.Attribute(XName.Get("tests")).Value);
+            Assert.AreEqual("52", node.Attribute(XName.Get("tests")).Value);
             Assert.AreEqual("14", node.Attribute(XName.Get("failures")).Value);
 
             Convert.ToDouble(node.Attribute(XName.Get("time")).Value);
@@ -61,7 +61,7 @@ namespace JUnit.Xml.TestLogger.AcceptanceTests
             Assert.IsNotNull(node);
             Assert.AreEqual("JUnit.Xml.TestLogger.NetCore.Tests.dll", node.Attribute(XName.Get("name")).Value);
             Assert.AreEqual("executor://nunit3testexecutor/", node.Attribute(XName.Get("hostname")).Value);
-            Assert.AreEqual("48", node.Attribute(XName.Get("tests")).Value);
+            Assert.AreEqual("52", node.Attribute(XName.Get("tests")).Value);
             Assert.AreEqual("14", node.Attribute(XName.Get("failures")).Value);
             Assert.AreEqual("6", node.Attribute(XName.Get("skipped")).Value);
 
@@ -80,7 +80,7 @@ namespace JUnit.Xml.TestLogger.AcceptanceTests
 
             // Check all test cases
             Assert.IsNotNull(node);
-            Assert.AreEqual(48, testcases.Count());
+            Assert.AreEqual(52, testcases.Count());
             Assert.IsTrue(testcases.All(x => double.TryParse(x.Attribute("time").Value, out _)));
 
             // Check failures

--- a/test/assets/JUnit.Xml.TestLogger.NetCore.Tests/UnitTest1.cs
+++ b/test/assets/JUnit.Xml.TestLogger.NetCore.Tests/UnitTest1.cs
@@ -146,7 +146,7 @@ namespace JUnit.Xml.TestLogger.NetFull.Tests
         }
 
         [Test]
-        public void Test()
+        public void TestA()
         {
         }
     }
@@ -161,7 +161,7 @@ namespace JUnit.Xml.TestLogger.NetFull.Tests
         }
 
         [Test]
-        public void Test()
+        public void TestB()
         {
         }
     }
@@ -176,7 +176,7 @@ namespace JUnit.Xml.TestLogger.NetFull.Tests
         }
 
         [Test]
-        public void Test()
+        public void TestC()
         {
         }
     }
@@ -191,7 +191,7 @@ namespace JUnit.Xml.TestLogger.NetFull.Tests
         }
 
         [Test]
-        public void Test()
+        public void TestD()
         {
         }
     }
@@ -205,7 +205,7 @@ namespace JUnit.Xml.TestLogger.NetFull.Tests
         }
 
         [Test]
-        public void Test()
+        public void TestE()
         {
         }
 

--- a/test/assets/JUnit.Xml.TestLogger.NetCore.Tests/UnitTest2.cs
+++ b/test/assets/JUnit.Xml.TestLogger.NetCore.Tests/UnitTest2.cs
@@ -108,7 +108,7 @@ namespace JUnit.Xml.TestLogger.Tests2
         }
 
         [Test]
-        public void Test()
+        public void TestA()
         {
         }
     }
@@ -123,7 +123,7 @@ namespace JUnit.Xml.TestLogger.Tests2
         }
 
         [Test]
-        public void Test()
+        public void TestB()
         {
         }
     }
@@ -138,7 +138,7 @@ namespace JUnit.Xml.TestLogger.Tests2
         }
 
         [Test]
-        public void Test()
+        public void TestC()
         {
         }
     }
@@ -153,7 +153,7 @@ namespace JUnit.Xml.TestLogger.Tests2
         }
 
         [Test]
-        public void Test()
+        public void TestD()
         {
         }
     }
@@ -167,7 +167,7 @@ namespace JUnit.Xml.TestLogger.Tests2
         }
 
         [Test]
-        public void Test()
+        public void TestE()
         {
         }
 


### PR DESCRIPTION
Resolves #4 

The acceptance test counts have been corrected from 48 to 52. The four missing tests represent tests with fixture data.

Confirmation this is a correction and not introducing an error:
```
Output of dotnet test on test\assets\JUnit.Xml.TestLogger.NetCore.Tests:

Test Run Failed.
Total tests: 52
     Passed: 24
     Failed: 14
    Skipped: 6
 Total time: 2.2389 Seconds

Output of dotnet test -t:

The following Tests are available:
    TestA
    TestD
    TestC
    TestB
    TestE
    TestE
    TestData(1,"A")
    TestData(1,"B")
    ... 
```

Additionally, by renaming the Test() methods to TestA, TestB... I verified that TestE was not present in the log produced by the master branch, but is now present twice per UnitTest folder, matching the list of tests which dotnet discovers. 