### PR TITLE
Fix: Period char is expected in method parameters outside of strings …

### DIFF
--- a/src/JUnit.Xml.TestLogger/JUnitXmlTestLogger.cs
+++ b/src/JUnit.Xml.TestLogger/JUnitXmlTestLogger.cs
@@ -223,7 +223,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.JUnit.Xml.TestLogger
                     }
                     else if (state == NameParseState.Parenthesis)
                     {
-                        if (thisChar == ')' || thisChar == '\\' || thisChar == '.')
+                        if (thisChar == ')' || thisChar == '\\')
                         {
                             throw new Exception("Found invalid characters");
                         }

--- a/test/JUnit.Xml.TestLogger.UnitTests/JUnitXmlTestLoggerTests.cs
+++ b/test/JUnit.Xml.TestLogger.UnitTests/JUnitXmlTestLoggerTests.cs
@@ -64,6 +64,10 @@ namespace JUnit.Xml.TestLogger.UnitTests
         [DataRow("z.y.x.a(\"arg\",2).b", "a(\"arg\",2)", "b")]
         [DataRow("a(\"arg\",2).b(\"arg\",2)", "a(\"arg\",2)", "b(\"arg\",2)")]
         [DataRow("z.y.x.a(\"arg\",2).b(\"arg\",2)", "a(\"arg\",2)", "b(\"arg\",2)")]
+        [DataRow("z.y.x.a(\"arg.())(\",2).b", "a(\"arg.())(\",2)", "b")]
+
+        // Examples with period in non string
+        [DataRow("a.b(0.5f)", "a", "b(0.5f)")]
 
         // Cover select cases with characters in strings that could cause issues
         [DataRow("z.y.x.a.b(\"arg\",\"\\\"\")", "a", "b(\"arg\",\"\\\"\")")]


### PR DESCRIPTION
I had overlooked that periods are expected charaters in method parameters, because of numeric data types like floats. 