### PR TITLE
Fix: Use the correct variable in the File Encoding error message.

### DIFF
--- a/src/JUnit.Xml.TestLogger/JUnitXmlTestLogger.cs
+++ b/src/JUnit.Xml.TestLogger/JUnitXmlTestLogger.cs
@@ -235,7 +235,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.JUnit.Xml.TestLogger
                 }
                 else
                 {
-                    Console.WriteLine($"JunitXML Logger: The provided File Encoding '{failureFormat}' is not a recognized option. Using default");
+                    Console.WriteLine($"JunitXML Logger: The provided File Encoding '{fileEncoding}' is not a recognized option. Using default");
                 }
             }
         }


### PR DESCRIPTION
Simple fix for using the wrong variable. 