### PR TITLE
testsuite's hostname attribute should be the machine name, not the executor

### DIFF
--- a/src/JUnit.Xml.TestLogger/JUnitXmlTestLogger.cs
+++ b/src/JUnit.Xml.TestLogger/JUnitXmlTestLogger.cs
@@ -444,7 +444,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.JUnit.Xml.TestLogger
             element.SetAttributeValue("errors", 0); // looks like this isn't supported by .net?
             element.SetAttributeValue("time", results.Sum(x => x.Duration.TotalSeconds));
             element.SetAttributeValue("timestamp", this.utcStartTime.ToString("s"));
-            element.SetAttributeValue("hostname", results.First().TestCase.ExecutorUri);
+            element.SetAttributeValue("hostname", results.First().HostName);
             element.SetAttributeValue("id", 0); // we never output multiple, so this is always zero.
             element.SetAttributeValue("package", Path.GetFileName(results.First().AssemblyPath));
 

--- a/src/JUnit.Xml.TestLogger/TestResultInfo.cs
+++ b/src/JUnit.Xml.TestLogger/TestResultInfo.cs
@@ -29,6 +29,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.JUnit.Xml.TestLogger
 
         public string AssemblyPath => this.result.TestCase.Source;
 
+        public string HostName => this.result.ComputerName;
+
         public string Namespace { get; private set; }
 
         public string Type { get; private set; }

--- a/test/JUnit.Xml.TestLogger.AcceptanceTests/JUnitTestLoggerAcceptanceTests.cs
+++ b/test/JUnit.Xml.TestLogger.AcceptanceTests/JUnitTestLoggerAcceptanceTests.cs
@@ -55,7 +55,10 @@ namespace JUnit.Xml.TestLogger.AcceptanceTests
 
             Assert.IsNotNull(node);
             Assert.AreEqual("JUnit.Xml.TestLogger.NetCore.Tests.dll", node.Attribute(XName.Get("name")).Value);
-            Assert.AreEqual("executor://nunit3testexecutor/", node.Attribute(XName.Get("hostname")).Value);
+
+            // hostname may change with every test run, can't predict an exact value, but it should not be empty
+            Assert.IsFalse(string.IsNullOrEmpty(node.Attribute(XName.Get("hostname")).Value));
+
             Assert.AreEqual("52", node.Attribute(XName.Get("tests")).Value);
             Assert.AreEqual("14", node.Attribute(XName.Get("failures")).Value);
             Assert.AreEqual("6", node.Attribute(XName.Get("skipped")).Value);

--- a/test/JUnit.Xml.TestLogger.AcceptanceTests/JUnitTestLoggerAcceptanceTests.cs
+++ b/test/JUnit.Xml.TestLogger.AcceptanceTests/JUnitTestLoggerAcceptanceTests.cs
@@ -55,9 +55,7 @@ namespace JUnit.Xml.TestLogger.AcceptanceTests
 
             Assert.IsNotNull(node);
             Assert.AreEqual("JUnit.Xml.TestLogger.NetCore.Tests.dll", node.Attribute(XName.Get("name")).Value);
-
-            // hostname may change with every test run, can't predict an exact value, but it should not be empty
-            Assert.IsFalse(string.IsNullOrEmpty(node.Attribute(XName.Get("hostname")).Value));
+            Assert.AreEqual(Environment.MachineName, node.Attribute(XName.Get("hostname")).Value);
 
             Assert.AreEqual("52", node.Attribute(XName.Get("tests")).Value);
             Assert.AreEqual("14", node.Attribute(XName.Get("failures")).Value);


### PR DESCRIPTION
See the schema documentation for the hostname attribute:  https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd#L171.

Fixes #28.