### PR TITLE
Skip system-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ provide additional control over the xml file so that the logged test results can
 Platform Specific Recommendations:
 
 - [GitLab CI/CD Recomendation](/docs/gitlab-recommendation.md)
-- [Jenkins Recomendation](/docs/jenkins-recommendation.md) 
+- [Jenkins Recomendation](/docs/jenkins-recommendation.md)
 - [CircleCI Recomendation](/docs/circleci-recommendation.md)
 
 After the logger name, command line arguments are provided as key/value pairs with the following general format. **Note** the quotes are required and key names are case sensitive.
@@ -66,7 +66,7 @@ After the logger name, command line arguments are provided as key/value pairs wi
 
 #### MethodFormat
 
-This option alters the `testcase name` attribute. By default, this contains only the method. Class, will add the class to the name. Full, will add the assembly/namespace/class to the method. 
+This option alters the `testcase name` attribute. By default, this contains only the method. Class, will add the class to the name. Full, will add the assembly/namespace/class to the method.
 
 We recommend this option for [GitLab](/docs/gitlab-recommendation.md) users.
 
@@ -78,7 +78,7 @@ We recommend this option for [GitLab](/docs/gitlab-recommendation.md) users.
 
 #### FailureBodyFormat
 
-When set to default, the body of a `failure` element will contain only the exception which is captured by vstest. Verbose will prepend the body with 'Expected X, Actual Y' similar to how it is displayed in the standard test output. 'Expected X, Actual Y' are normally only contained in the failure message. Additionally, Verbose will include standard output from the test in the failure message. 
+When set to default, the body of a `failure` element will contain only the exception which is captured by vstest. Verbose will prepend the body with 'Expected X, Actual Y' similar to how it is displayed in the standard test output. 'Expected X, Actual Y' are normally only contained in the failure message. Additionally, Verbose will include standard output from the test in the failure message.
 
 We recommend this option for [GitLab](/docs/gitlab-recommendation.md) users.
 
@@ -86,6 +86,16 @@ We recommend this option for [GitLab](/docs/gitlab-recommendation.md) users.
 
 - FailureBodyFormat=Default
 - FailureBodyFormat=Verbose
+
+#### SkipSystemOut
+
+When set to false, the text of a `system-out` element will include standard output from the test execution.
+Otherwise, it will be empty.
+
+##### Allowed Values
+
+- SkipSystemOut=True
+- SkipSystemOut=False
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ provide additional control over the xml file so that the logged test results can
 Platform Specific Recommendations:
 
 - [GitLab CI/CD Recomendation](/docs/gitlab-recommendation.md)
-- [Jenkins Recomendation](/docs/jenkins-recommendation.md)
+- [Jenkins Recomendation](/docs/jenkins-recommendation.md) 
 - [CircleCI Recomendation](/docs/circleci-recommendation.md)
 
 After the logger name, command line arguments are provided as key/value pairs with the following general format. **Note** the quotes are required and key names are case sensitive.
@@ -66,7 +66,7 @@ After the logger name, command line arguments are provided as key/value pairs wi
 
 #### MethodFormat
 
-This option alters the `testcase name` attribute. By default, this contains only the method. Class, will add the class to the name. Full, will add the assembly/namespace/class to the method.
+This option alters the `testcase name` attribute. By default, this contains only the method. Class, will add the class to the name. Full, will add the assembly/namespace/class to the method. 
 
 We recommend this option for [GitLab](/docs/gitlab-recommendation.md) users.
 
@@ -78,7 +78,7 @@ We recommend this option for [GitLab](/docs/gitlab-recommendation.md) users.
 
 #### FailureBodyFormat
 
-When set to default, the body of a `failure` element will contain only the exception which is captured by vstest. Verbose will prepend the body with 'Expected X, Actual Y' similar to how it is displayed in the standard test output. 'Expected X, Actual Y' are normally only contained in the failure message. Additionally, Verbose will include standard output from the test in the failure message.
+When set to default, the body of a `failure` element will contain only the exception which is captured by vstest. Verbose will prepend the body with 'Expected X, Actual Y' similar to how it is displayed in the standard test output. 'Expected X, Actual Y' are normally only contained in the failure message. Additionally, Verbose will include standard output from the test in the failure message. 
 
 We recommend this option for [GitLab](/docs/gitlab-recommendation.md) users.
 

--- a/src/JUnit.Xml.TestLogger/JunitXmlSerializer.cs
+++ b/src/JUnit.Xml.TestLogger/JunitXmlSerializer.cs
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.Junit.Xml.TestLogger
 
         public FailureBodyFormat FailureBodyFormatOption { get; private set; } = FailureBodyFormat.Default;
 
-        public bool SkipSystemOutOption = false;
+        public bool SkipSystemOutOption { get; private set; } = false;
 
         public static IEnumerable<TestSuite> GroupTestSuites(IEnumerable<TestSuite> suites)
         {

--- a/src/JUnit.Xml.TestLogger/JunitXmlSerializer.cs
+++ b/src/JUnit.Xml.TestLogger/JunitXmlSerializer.cs
@@ -22,6 +22,8 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.Junit.Xml.TestLogger
 
         public const string FailureBodyFormatKey = "FailureBodyFormat";
 
+        public const string SkipSystemOutKey = "SkipSystemOut";
+
         private const string ResultStatusPassed = "Passed";
         private const string ResultStatusFailed = "Failed";
 
@@ -220,6 +222,16 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.Junit.Xml.TestLogger
                 stdErr.AppendLine($"{m.Level} - {m.Message}");
             }
 
+            var systemOutContent = stdOut.ToString();
+            if (loggerConfiguration.Values.TryGetValue(SkipSystemOutKey, out string systemOut))
+            {
+                if (string.Equals(systemOut.Trim(), "True", StringComparison.OrdinalIgnoreCase))
+                {
+                    systemOutContent = "";
+                }
+            }
+            var systemOutElement = new XElement("system-out", systemOutContent);
+
             // Adding required properties, system-out, and system-err elements in the correct
             // positions as required by the xsd. In system-out collapse consequtive newlines to a
             // single newline.
@@ -227,7 +239,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.Junit.Xml.TestLogger
                 "testsuite",
                 new XElement("properties"),
                 testCaseElements,
-                new XElement("system-out", stdOut.ToString()),
+                systemOutElement,
                 new XElement("system-err", stdErr.ToString()));
 
             element.SetAttributeValue("name", Path.GetFileName(results.First().AssemblyPath));

--- a/src/JUnit.Xml.TestLogger/JunitXmlSerializer.cs
+++ b/src/JUnit.Xml.TestLogger/JunitXmlSerializer.cs
@@ -227,7 +227,7 @@ namespace Microsoft.VisualStudio.TestPlatform.Extension.Junit.Xml.TestLogger
             {
                 if (string.Equals(systemOut.Trim(), "True", StringComparison.OrdinalIgnoreCase))
                 {
-                    systemOutContent = "";
+                    systemOutContent = string.Empty;
                 }
             }
             var systemOutElement = new XElement("system-out", systemOutContent);

--- a/test/JUnit.Xml.TestLogger.AcceptanceTests/JUnitTestLoggerFormatOptionsAcceptanceTests.cs
+++ b/test/JUnit.Xml.TestLogger.AcceptanceTests/JUnitTestLoggerFormatOptionsAcceptanceTests.cs
@@ -180,5 +180,53 @@ namespace JUnit.Xml.TestLogger.AcceptanceTests
 
             Assert.IsTrue(new JunitXmlValidator().IsValid(resultsXml));
         }
+
+        [TestMethod]
+        public void SkipSystemOut_Default_ShouldContainSystemOutElement()
+        {
+            DotnetTestFixture.Execute("failure-default-test-results.xml");
+            string resultsFile = Path.Combine(DotnetTestFixture.RootDirectory, "failure-default-test-results.xml");
+            XDocument resultsXml = XDocument.Load(resultsFile);
+
+            var systemOuts = resultsXml.XPathSelectElements("/testsuites/testsuite")
+                .Descendants()
+                .Where(x => x.Name.LocalName == "system-out")
+                .ToList();
+
+            foreach (var systemOut in systemOuts)
+            {
+                // Strip new line and carrige return. These may be inconsistent depending on
+                // environment settings
+                var message = systemOut.Value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+
+                Assert.IsFalse(String.IsNullOrEmpty(message));
+            }
+
+            Assert.IsTrue(new JunitXmlValidator().IsValid(resultsXml));
+        }
+
+        [TestMethod]
+        public void SkipSystemOut_Default_ShouldntContainContentInSystemOutElement()
+        {
+            DotnetTestFixture.Execute("failure-default-test-results.xml;SkipSystemOut=True");
+            string resultsFile = Path.Combine(DotnetTestFixture.RootDirectory, "failure-default-test-results.xml");
+            XDocument resultsXml = XDocument.Load(resultsFile);
+
+            var systemOuts = resultsXml.XPathSelectElements("/testsuites/testsuite")
+                .Descendants()
+                .Where(x => x.Name.LocalName == "system-out")
+                .ToList();
+
+            foreach (var systemOut in systemOuts)
+            {
+                // Strip new line and carrige return. These may be inconsistent depending on
+                // environment settings
+                var message = systemOut.Value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+
+                Assert.IsTrue(String.IsNullOrEmpty(message));
+            }
+
+            Assert.IsTrue(new JunitXmlValidator().IsValid(resultsXml));
+        }
     }
 }

--- a/test/JUnit.Xml.TestLogger.AcceptanceTests/JUnitTestLoggerFormatOptionsAcceptanceTests.cs
+++ b/test/JUnit.Xml.TestLogger.AcceptanceTests/JUnitTestLoggerFormatOptionsAcceptanceTests.cs
@@ -199,7 +199,7 @@ namespace JUnit.Xml.TestLogger.AcceptanceTests
                 // environment settings
                 var message = systemOut.Value.Replace("\r", string.Empty).Replace("\n", string.Empty);
 
-                Assert.IsFalse(String.IsNullOrEmpty(message));
+                Assert.IsFalse(string.IsNullOrEmpty(message));
             }
 
             Assert.IsTrue(new JunitXmlValidator().IsValid(resultsXml));
@@ -223,7 +223,7 @@ namespace JUnit.Xml.TestLogger.AcceptanceTests
                 // environment settings
                 var message = systemOut.Value.Replace("\r", string.Empty).Replace("\n", string.Empty);
 
-                Assert.IsTrue(String.IsNullOrEmpty(message));
+                Assert.IsTrue(string.IsNullOrEmpty(message));
             }
 
             Assert.IsTrue(new JunitXmlValidator().IsValid(resultsXml));


### PR DESCRIPTION
### What

Allow to customise the system-out xml element, so it can be skipped (no content) in some cases

### Why

This is quite handy when the system-out is too verbose. And the CI can complain if the JUnit files are too massive